### PR TITLE
Refactor: Rename Upgrader to VersionChanger in Composer Plugin.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,11 +19,11 @@
     },
     "autoload": {
         "psr-4": {
-            "DigitalPolygon\\Composer\\Drupal\\Upgrader\\": "src/"
+            "DigitalPolygon\\Composer\\Drupal\\VersionChanger\\": "src/"
         }
     },
     "extra": {
-        "class": "DigitalPolygon\\Composer\\Drupal\\Upgrader\\Plugin",
+        "class": "DigitalPolygon\\Composer\\Drupal\\VersionChanger\\Plugin",
         "branch-alias": {
             "dev-main": "1.0.x-dev"
         }

--- a/src/CommandProvider.php
+++ b/src/CommandProvider.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DigitalPolygon\Composer\Drupal\Upgrader;
+namespace DigitalPolygon\Composer\Drupal\VersionChanger;
 
 use Composer\Plugin\Capability\CommandProvider as CommandProviderCapability;
 
@@ -16,7 +16,6 @@ class CommandProvider implements CommandProviderCapability
    */
     public function getCommands()
     {
-        echo "hello world";
         return [new ComposerUpdateDrupalCommand()];
     }
 }

--- a/src/ComposerUpdateDrupalCommand.php
+++ b/src/ComposerUpdateDrupalCommand.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DigitalPolygon\Composer\Drupal\Upgrader;
+namespace DigitalPolygon\Composer\Drupal\VersionChanger;
 
 use Composer\Command\BaseCommand;
 use Symfony\Component\Console\Input\InputInterface;
@@ -24,7 +24,7 @@ final class ComposerUpdateDrupalCommand extends BaseCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $updater = new DrupalUpgrader($this->requireComposer(), $this->getApplication(), $input, $output, $this->getIO());
+        $updater = new DrupalVersionChanger($this->requireComposer(), $this->getApplication(), $input, $output, $this->getIO());
         return $updater->execute();
     }
 }

--- a/src/DrupalVersionChanger.php
+++ b/src/DrupalVersionChanger.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace DigitalPolygon\Composer\Drupal\Upgrader;
+namespace DigitalPolygon\Composer\Drupal\VersionChanger;
 
 use Composer\Composer;
 use Composer\Console\Application;
@@ -27,7 +27,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  * 6. Replaces wildcard versions in composer.json with caret versions from composer.lock.
  * 7. Updates composer.lock hashes.
  */
-final class DrupalUpgrader
+final class DrupalVersionChanger
 {
     /**
      * The Composer service instance.

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace DigitalPolygon\Composer\Drupal\Upgrader;
+namespace DigitalPolygon\Composer\Drupal\VersionChanger;
 
 use Composer\Composer;
 use Composer\IO\IOInterface;
 use Composer\Plugin\Capable;
 use Composer\Plugin\PluginInterface;
 use Composer\Plugin\Capability\CommandProvider;
-use DigitalPolygon\Composer\Drupal\Upgrader\CommandProvider as UpgradeDrupalCommandProvider;
+use DigitalPolygon\Composer\Drupal\VersionChanger\CommandProvider as UpgradeDrupalCommandProvider;
 
 /**
  * Composer plugin for handling drupal upgrades.
@@ -30,7 +30,6 @@ class Plugin implements PluginInterface, Capable
      */
     public function activate(Composer $composer, IOInterface $io): void
     {
-        echo "world";
         $this->composer = $composer;
         $this->io = $io;
     }
@@ -40,8 +39,6 @@ class Plugin implements PluginInterface, Capable
      */
     public function deactivate(Composer $composer, IOInterface $io)
     {
-        // TODO: Implement deactivate() method.
-        $x = 5;
     }
 
     /**
@@ -49,8 +46,6 @@ class Plugin implements PluginInterface, Capable
      */
     public function uninstall(Composer $composer, IOInterface $io)
     {
-        // TODO: Implement uninstall() method.
-        $x = 5;
     }
 
     /**


### PR DESCRIPTION
### Purpose:
These changes restructure the codebase to use a more descriptive namespace (`VersionChanger` instead of `Upgrader`) for clarity and consistency. This aligns with the functionality of updating Drupal versions and related tasks.

### Changes Made:
- Updated `composer.json` to change namespace and autoload paths to `DigitalPolygon\Composer\Drupal\VersionChanger`.
- Modified classes in `src/` directory to reflect namespace change from `DigitalPolygon\Composer\Drupal\Upgrader` to `DigitalPolygon\Composer\Drupal\VersionChanger`.
- Renamed `DrupalUpgrader` class to `DrupalVersionChanger` throughout the codebase.
- Removed unused `echo` statements and commented-out code in `Plugin.php`.

### Additional Notes:
No functional changes were made besides namespace and class renaming to ensure clear code organization.

This pull request aims to enhance code clarity and maintainability by aligning namespaces with their intended functionality.

Thanks.
