### PR TITLE
Issue 7: Add additional configuration options for plugin.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,37 @@
 
 ## What problem does this plugin actually solve?
 
-It removes the "Composer dependency hell" phase of upgrading Drupal core. With
+It removes, or greatly eases, the "Composer dependency hell" phase of upgrading Drupal core. With
 this plugin, you can run a command that effectively says "This is the version of
 Drupal core I want to upgrade to, do whatever you need to get me there."
+
+## What does this plugin do?
+
+It provides commands for helping you upgrade Drupal core. It manipulates Composer and effectively wraps `composer update ...`.
+
+By default, when updating, the following flags are passed to the update command:
+
+- `--no-scripts`
+- `--no-plugins`
+- `--prefer-lowest`
+
+Scripts and plugins are disabled by default in order to avoid interference from other scripts that might otherwise cause
+the update process to fail (such as Composer patches failing to apply a patch to a new version of a package).
+
+Preferred package versions are their lowest by default. This is done to help minimize validation of other modules that
+must be updated in order to get to the targeted version of core (i.e. the lowest compatible version of a module will
+likely have fewer changes compared to higher versions, thus reducing the amount of functionality you need to verify
+with the new module version).
+
+`--ignore-platform-reqs` can also be configured to pass to the core update command, but this is disabled by default as
+to ensure platform compatibility remains (doesn't make sense to upgrade to a version of a module the requires PHP 8.3
+if your running PHP 8.2). In the future, the update command may default to ignoring platform requirements, as that 
+removes an additional barrier to updating packages purley based on semantic versioning compatibility.
+
+See the configuration section below for more details.
+
+Again, the goal is to improve the chances of successfully updating to the targeted version of core with the least amount
+of manual intervention possible, which this default configuration helps with the most.
 
 ## Features
 
@@ -110,7 +138,7 @@ specified in the manifest).
 
 ### Usage with Flags
 
-You can specify the update behavior using the following flags:
+Instead of specifying a specific version, you can specify one of the following flags to dynamically calculate the version to update to:
 
 2. `--latest-minor`: Update to the latest stable minor version within the currently installed major version of Drupal core.
 3. `--latest-major`: Update to the latest stable major version of Drupal core. This option will upgrade your site to the latest available version of Drupal.
@@ -119,7 +147,7 @@ You can specify the update behavior using the following flags:
 ## Configuration
 
 The plugin can be configured via the extra section of `composer.json` file in your project root.
-All configuration options are optional. The values specified below are the defaults.
+All configuration options are optional. The values specified below are the defaults:
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -116,6 +116,58 @@ You can specify the update behavior using the following flags:
 3. `--latest-major`: Update to the latest stable major version of Drupal core. This option will upgrade your site to the latest available version of Drupal.
 4. `--next-major`: Update to the latest stable of the next major version of Drupal core.
 
+## Configuration
+
+The plugin can be configured via the extra section of `composer.json` file in your project root.
+All configuration options are optional. The values specified below are the defaults.
+
+```json
+{
+    "extra": {
+        "drupal-upgrade-plugin": {
+            "ignore-platform-reqs": false,
+            "include-root-dependencies": false,
+            "prefer-lowest": true,
+            "manifest-file": {
+                "path": "./drupal_manifest",
+                "name": "project/drupal-manifest"
+            },
+            "packages-linked-to-core-version": [
+                "drupal/core-composer-scaffold",
+                "drupal/core-project-message",
+                "drupal/core-recommended",
+                "drupal/core-dev",
+                "drupal/core"
+            ]
+        },
+    }
+}
+```
+
+**ignore-platform-reqs**
+
+Set to `true` to ignore platform requirements when updating packages.
+
+**include-root-dependencies**
+
+Set to `true` to allow updates of packages in the root composer.json.
+
+**prefer-lowest**
+
+Set to `true` to prefer the lowest version of packages that satisfy the constraints.
+
+**manifest-file.path**
+
+The path to the manifest file repository.
+
+**manifest-file.name**
+
+The name of the manifest file package.
+
+**packages-linked-to-core-version**
+
+A list of packages that share their versioning with Drupal core.
+
 ## Contributing
 
 We welcome contributions to enhance the functionality and features of this plugin. Please fork the repository and submit pull requests for any improvements or bug fixes.

--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ All configuration options are optional. The values specified below are the defau
             "ignore-platform-reqs": false,
             "include-root-dependencies": false,
             "prefer-lowest": true,
+            "no-scripts": true,
+            "no-plugins": true,
             "manifest-file": {
                 "path": "./drupal_manifest",
                 "name": "project/drupal-manifest"
@@ -167,6 +169,14 @@ The name of the manifest file package.
 **packages-linked-to-core-version**
 
 A list of packages that share their versioning with Drupal core.
+
+**no-scripts**
+
+Set to `true` to disable scripts during the update process.
+
+**no-plugins**
+
+Set to `true` to disable plugins during the update process.
 
 ## Contributing
 

--- a/src/ApplicationAwareInterface.php
+++ b/src/ApplicationAwareInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace DigitalPolygon\Composer\Drupal\VersionChanger;
+
+use Composer\Console\Application;
+
+interface ApplicationAwareInterface {
+    public function setApplication(Application $application);
+    public function getApplication(): Application|null;
+}

--- a/src/ApplicationAwareTrait.php
+++ b/src/ApplicationAwareTrait.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace DigitalPolygon\Composer\Drupal\VersionChanger;
+
+use Composer\Console\Application;
+
+trait ApplicationAwareTrait {
+
+    protected ?Application $application = null;
+
+    public function setApplication(Application $application) {
+        $this->application = $application;
+    }
+
+    public function getApplication(): Application|null {
+        return $this->application;
+    }
+}

--- a/src/ComposerFileManager.php
+++ b/src/ComposerFileManager.php
@@ -30,11 +30,12 @@ class ComposerFileManager {
     protected readonly Filesystem $filesystem,
     protected readonly IOInterface $io,
     protected readonly ComposerManipulator $composerManipulator,
+    protected readonly Configuration $configuration,
   ) {
     $composerFilePath = Factory::getComposerFile();
     $this->composerFile = new JsonFile($composerFilePath);
     $this->composerLockFile = new JsonFile(Factory::getLockFile($composerFilePath));
-    $this->manifestFile = new JsonFile('./drupal_manifest/composer.json');
+    $this->manifestFile = new JsonFile($this->configuration->getManifestFileRepositoryPath());
   }
 
   public function backupFiles(): void {
@@ -101,7 +102,7 @@ class ComposerFileManager {
   public function updatePackageRequirementsForRootAndManifest(): void {
     $composerRoot = $this->composerFile->read();
     $manifestFile = $this->manifestFile->read();
-    $drupalCorePackages = $this->composerManipulator->getPresentDrupalCoreRootPackages();
+    $drupalCorePackages = $this->configuration->getDrupalCoreVersionLinkedPackages();
     $manifestFileRequiredPackages = array_keys($manifestFile['require']);
     $currentConstrainedVersions = array_merge($composerRoot['require'], $composerRoot['require-dev'], $manifestFile['require']);
     $currentInstalledVersions = [];

--- a/src/ComposerFileManager.php
+++ b/src/ComposerFileManager.php
@@ -102,7 +102,7 @@ class ComposerFileManager {
   public function updatePackageRequirementsForRootAndManifest(): void {
     $composerRoot = $this->composerFile->read();
     $manifestFile = $this->manifestFile->read();
-    $drupalCorePackages = $this->configuration->getDrupalCoreVersionLinkedPackages();
+    $drupalCorePackages = $this->composerManipulator->getPresentDrupalCoreRootPackages();
     $manifestFileRequiredPackages = array_keys($manifestFile['require']);
     $currentConstrainedVersions = array_merge($composerRoot['require'], $composerRoot['require-dev'], $manifestFile['require']);
     $currentInstalledVersions = [];

--- a/src/ComposerFileManager.php
+++ b/src/ComposerFileManager.php
@@ -35,7 +35,7 @@ class ComposerFileManager {
     $composerFilePath = Factory::getComposerFile();
     $this->composerFile = new JsonFile($composerFilePath);
     $this->composerLockFile = new JsonFile(Factory::getLockFile($composerFilePath));
-    $this->manifestFile = new JsonFile($this->configuration->getManifestFileRepositoryPath());
+    $this->manifestFile = new JsonFile($this->configuration->getManifestFileRepositoryPath() . '/composer.json');
   }
 
   public function backupFiles(): void {

--- a/src/ComposerManipulator.php
+++ b/src/ComposerManipulator.php
@@ -21,7 +21,7 @@ class ComposerManipulator {
    * @return void
    */
   public function convertCorePackagesToWildcards(): void {
-    $this->convertPackagesToWildcards($this->configuration->getDrupalCoreVersionLinkedPackages());
+    $this->convertPackagesToWildcards($this->getPresentDrupalCoreRootPackages());
   }
 
   /**
@@ -54,4 +54,26 @@ class ComposerManipulator {
     $this->composer->getPackage()->setDevRequires($devRequires);
     $this->composer->getPackage()->setRequires($requires);
   }
+
+    /**
+     * Get list of Drupal core packages present in loaded composer.
+     *
+     * @return array
+     */
+    public function getPresentDrupalCoreRootPackages(): array {
+        $presentDrupalCorePackages = [];
+        $devRequires = $this->composer->getPackage()->getDevRequires();
+        $requires = $this->composer->getPackage()->getRequires();
+        foreach ($devRequires as $packageName => $package) {
+            if (in_array($packageName, $this->configuration->getDrupalCoreVersionLinkedPackages())) {
+                $presentDrupalCorePackages[] = $packageName;
+            }
+        }
+        foreach ($requires as $packageName => $package) {
+            if (in_array($packageName, $this->configuration->getDrupalCoreVersionLinkedPackages())) {
+                $presentDrupalCorePackages[] = $packageName;
+            }
+        }
+        return $presentDrupalCorePackages;
+    }
 }

--- a/src/ComposerManipulator.php
+++ b/src/ComposerManipulator.php
@@ -7,49 +7,11 @@ use Composer\Package\Link;
 use Composer\Semver\Constraint\MatchAllConstraint;
 
 class ComposerManipulator {
-  protected readonly array $defaultDrupalCorePackages;
 
-  public function __construct(protected readonly Composer $composer) {
-    $this->defaultDrupalCorePackages = [
-      'drupal/core',
-      'drupal/core-recommended',
-      'drupal/core-composer-scaffold',
-      'drupal/core-project-message',
-      'drupal/core-dev',
-    ];
-  }
-
-  public function getPresentDrupalCorePackages() {
-    $presentDrupalCorePackages = [];
-    foreach ($this->defaultDrupalCorePackages as $package) {
-      if ($this->composer->getRepositoryManager()->getLocalRepository()->findPackage($package, '*')) {
-        $presentDrupalCorePackages[] = $package;
-      }
-    }
-    return $presentDrupalCorePackages;
-  }
-
-  /**
-   * Get list of Drupal core packages present in loaded composer.
-   *
-   * @return array
-   */
-  public function getPresentDrupalCoreRootPackages(): array {
-    $presentDrupalCorePackages = [];
-    $devRequires = $this->composer->getPackage()->getDevRequires();
-    $requires = $this->composer->getPackage()->getRequires();
-    foreach ($devRequires as $packageName => $package) {
-      if (in_array($packageName, $this->defaultDrupalCorePackages)) {
-        $presentDrupalCorePackages[] = $packageName;
-      }
-    }
-    foreach ($requires as $packageName => $package) {
-      if (in_array($packageName, $this->defaultDrupalCorePackages)) {
-        $presentDrupalCorePackages[] = $packageName;
-      }
-    }
-    return $presentDrupalCorePackages;
-  }
+  public function __construct(
+      protected readonly Composer $composer,
+      protected readonly Configuration $configuration,
+  ) {}
 
   /**
    * Convert core packages to matchall constraint in loaded composer.
@@ -59,7 +21,7 @@ class ComposerManipulator {
    * @return void
    */
   public function convertCorePackagesToWildcards(): void {
-    $this->convertPackagesToWildcards($this->getPresentDrupalCoreRootPackages());
+    $this->convertPackagesToWildcards($this->configuration->getDrupalCoreVersionLinkedPackages());
   }
 
   /**

--- a/src/ComposerUpdateDrupalCommand.php
+++ b/src/ComposerUpdateDrupalCommand.php
@@ -109,6 +109,9 @@ final class ComposerUpdateDrupalCommand extends BaseCommand
       if ($configuration->preferLowest()) {
         $parameters['--prefer-lowest'] = true;
       }
+      if ($configuration->ignorePlatformReqs()) {
+          $parameters['--ignore-platform-reqs'] = true;
+      }
       return $this->runComposerUpdate($parameters, $output);
     }
 
@@ -135,6 +138,8 @@ final class ComposerUpdateDrupalCommand extends BaseCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+      /** @var Configuration $configuration */
+      $configuration = Plugin::getContainer()->get('configuration');
       $validateResult = $this->validate($input);
       if ($validateResult !== 0) {
         $this->getIO()->writeError('<error>Failed to validate Drupal core upgrade prerequisites.</error>');
@@ -160,7 +165,11 @@ final class ComposerUpdateDrupalCommand extends BaseCommand
         }
         $composerFileManager->updatePackageRequirementsForRootAndManifest();
         $this->getApplication()->resetComposer();
-        $result = $this->runComposerUpdate(['--lock' => true], $output);
+        $parameters = ['--lock' => true];
+        if ($configuration->ignorePlatformReqs()) {
+          $parameters['--ignore-platform-reqs'] = true;
+        }
+        $result = $this->runComposerUpdate($parameters, $output);
         if ($result !== 0) {
           $this->getIO()->writeError('<error>Failed to update composer.lock file.</error>');
           $composerFileManager->restoreFiles();

--- a/src/ComposerUpdateDrupalCommand.php
+++ b/src/ComposerUpdateDrupalCommand.php
@@ -36,6 +36,22 @@ final class ComposerUpdateDrupalCommand extends BaseCommand
         $this->addOption('next-major', null, InputOption::VALUE_NONE, 'Update to the latest stable of the next major version of Drupal core. This option prepares your site for the next major release.');
     }
 
+    /**
+     * {@inheritdoc}
+     */
+    public function initialize(InputInterface $input, OutputInterface $output)
+    {
+        Plugin::getContainer()
+            ->inflector(ApplicationAwareInterface::class)
+            ->invokeMethod('setApplication', [$this->getApplication()]);
+        Plugin::getContainer()
+            ->inflector(OutputAwareInterface::class)
+            ->invokeMethod('setOutput', [$output]);
+        Plugin::getContainer()
+            ->inflector(InputAwareInterface::class)
+            ->invokeMethod('setInput', [$input]);
+    }
+
     protected function validateInput(InputInterface $input): int {
       $options = $input->getOptions();
       $arguments = $input->getArguments();
@@ -89,32 +105,6 @@ final class ComposerUpdateDrupalCommand extends BaseCommand
       return 0;
     }
 
-    protected function runComposerPackageUpdates(OutputInterface $output): int {
-      /** @var Configuration $configuration */
-      $configuration = Plugin::getContainer()->get('configuration');
-      $packages = array_merge([$configuration->getManifestPackageName()], array_map(
-        fn($package) => $package . ':' . $this->targetDrupalCoreVersion,
-        $configuration->getDrupalCoreVersionLinkedPackages(),
-      ));
-      $parameters = [
-        'packages' => $packages,
-        '--minimal-changes' => true,
-      ];
-      if ($configuration->includeRootDependencies()) {
-        $parameters['-W'] = true;
-      }
-      else {
-        $parameters['-w'] = true;
-      }
-      if ($configuration->preferLowest()) {
-        $parameters['--prefer-lowest'] = true;
-      }
-      if ($configuration->ignorePlatformReqs()) {
-          $parameters['--ignore-platform-reqs'] = true;
-      }
-      return $this->runComposerUpdate($parameters, $output);
-    }
-
     protected function runComposerUpdate($parameters, OutputInterface $output): int {
       if ($this->getIO()->isInteractive() && !array_key_exists('--no-interaction', $parameters)) {
         $parameters['--no-interaction'] = true;
@@ -146,6 +136,8 @@ final class ComposerUpdateDrupalCommand extends BaseCommand
         return $validateResult;
       }
       $container = Plugin::getContainer();
+      /** @var UpdateRunner $updateRunner */
+      $updateRunner = $container->get('updateRunner');
       /** @var \Composer\Composer $composer */
       $composer = $container->get('composer');
       /** @var \DigitalPolygon\Composer\Drupal\VersionChanger\ComposerFileManager $composerFileManager */
@@ -157,19 +149,14 @@ final class ComposerUpdateDrupalCommand extends BaseCommand
         $manifestWildcardRepo = $composerFileManager->getWildcardManifestRepository();
         $composer->getRepositoryManager()->prependRepository($manifestWildcardRepo);
         $composerManipulator->convertCorePackagesToWildcards();
-        $result = $this->runComposerPackageUpdates($output);
+        $result = $updateRunner->updateCore($this->targetDrupalCoreVersion);
         if ($result !== 0) {
           $this->getIO()->writeError('<error>Failed to update Drupal core and manifest packages.</error>');
           $composerFileManager->restoreFiles();
           return $result;
         }
         $composerFileManager->updatePackageRequirementsForRootAndManifest();
-        $this->getApplication()->resetComposer();
-        $parameters = ['--lock' => true];
-        if ($configuration->ignorePlatformReqs()) {
-          $parameters['--ignore-platform-reqs'] = true;
-        }
-        $result = $this->runComposerUpdate($parameters, $output);
+        $result = $updateRunner->updateLock();
         if ($result !== 0) {
           $this->getIO()->writeError('<error>Failed to update composer.lock file.</error>');
           $composerFileManager->restoreFiles();

--- a/src/ComposerUpdateDrupalCommand.php
+++ b/src/ComposerUpdateDrupalCommand.php
@@ -90,18 +90,25 @@ final class ComposerUpdateDrupalCommand extends BaseCommand
     }
 
     protected function runComposerPackageUpdates(OutputInterface $output): int {
-      /** @var \DigitalPolygon\Composer\Drupal\VersionChanger\ComposerManipulator $composerManipulator */
-      $composerManipulator = Plugin::getContainer()->get('composerManipulator');
-      $packages = array_merge(['project/drupal-manifest'], array_map(
+      /** @var Configuration $configuration */
+      $configuration = Plugin::getContainer()->get('configuration');
+      $packages = array_merge([$configuration->getManifestPackageName()], array_map(
         fn($package) => $package . ':' . $this->targetDrupalCoreVersion,
-        $composerManipulator->getPresentDrupalCorePackages(),
+        $configuration->getDrupalCoreVersionLinkedPackages(),
       ));
       $parameters = [
         'packages' => $packages,
-        '-w' => true,
         '--minimal-changes' => true,
-        '--prefer-lowest' => true,
       ];
+      if ($configuration->includeRootDependencies()) {
+        $parameters['-W'] = true;
+      }
+      else {
+        $parameters['-w'] = true;
+      }
+      if ($configuration->preferLowest()) {
+        $parameters['--prefer-lowest'] = true;
+      }
       return $this->runComposerUpdate($parameters, $output);
     }
 

--- a/src/ComposerUpdateDrupalCommand.php
+++ b/src/ComposerUpdateDrupalCommand.php
@@ -105,31 +105,11 @@ final class ComposerUpdateDrupalCommand extends BaseCommand
       return 0;
     }
 
-    protected function runComposerUpdate($parameters, OutputInterface $output): int {
-      if ($this->getIO()->isInteractive() && !array_key_exists('--no-interaction', $parameters)) {
-        $parameters['--no-interaction'] = true;
-      }
-      $update_command = $this->getApplication()->find('update');
-      // Run composer update and capture the exit code.
-      $input = new ArrayInput($parameters);
-      $exit_code = $update_command->run($input, $output);
-      // Check for errors.
-      if ($exit_code !== 0) {
-        $this->getIO()->writeError("Failed to run 'composer update', Could not update dependencies.");
-        return $exit_code;
-      } else {
-        $this->getIO()->write('<info>Composer update completed successfully.</info>');
-      }
-      return 0;
-    }
-
     /**
      * {@inheritdoc}
      */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-      /** @var Configuration $configuration */
-      $configuration = Plugin::getContainer()->get('configuration');
       $validateResult = $this->validate($input);
       if ($validateResult !== 0) {
         $this->getIO()->writeError('<error>Failed to validate Drupal core upgrade prerequisites.</error>');

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -11,6 +11,8 @@ class Configuration {
     protected readonly string $manifestPackageName;
     protected readonly bool $includeRootDependencies;
     protected readonly bool $preferLowest;
+    protected readonly bool $noPlugins;
+    protected readonly bool $noScripts;
 
     public function __construct(protected readonly Composer $composer) {
         $extra = $this->composer->getPackage()->getExtra();

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -29,6 +29,8 @@ class Configuration {
         $this->manifestFileRepositoryPath = $pluginConfiguration['manifest-file']['path'] ?? './drupal_manifest';
         $this->manifestPackageName = $pluginConfiguration['manifest-file']['name'] ?? 'project/drupal-manifest';
         $this->preferLowest = $pluginConfiguration['prefer-lowest'] ?? true;
+        $this->noScripts = $pluginConfiguration['no-scripts'] ?? true;
+        $this->noPlugins = $pluginConfiguration['no-plugins'] ?? true;
     }
 
     public function getDrupalCoreVersionLinkedPackages() {
@@ -59,5 +61,13 @@ class Configuration {
 
     public function preferLowest(): bool {
         return $this->preferLowest;
+    }
+
+    public function noScripts(): bool {
+        return $this->noScripts;
+    }
+
+    public function noPlugins(): bool {
+        return $this->noPlugins;
     }
 }

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace DigitalPolygon\Composer\Drupal\VersionChanger;
+
+use Composer\Composer;
+
+class Configuration {
+    protected readonly bool $ignorePlatformReqs;
+    protected readonly array $drupalCoreVersionLinkedPackages;
+    protected readonly string $manifestFileRepositoryPath;
+    protected readonly string $manifestPackageName;
+    protected readonly bool $includeRootDependencies;
+    protected readonly bool $preferLowest;
+
+    public function __construct(protected readonly Composer $composer) {
+        $extra = $this->composer->getPackage()->getExtra();
+        $pluginConfiguration = $extra['drupal-upgrade-plugin'] ?? [];
+        $this->includeRootDependencies = $pluginConfiguration['include-root-dependencies'] ?? false;
+        $this->ignorePlatformReqs = $pluginConfiguration['ignore-platform-reqs'] ?? false;
+        $this->drupalCoreVersionLinkedPackages = $pluginConfiguration['packages-linked-to-core-version'] ?? [
+            'drupal/core-composer-scaffold',
+            'drupal/core-project-message',
+            'drupal/core-recommended',
+            'drupal/core-dev',
+            'drupal/core',
+        ];
+        $this->manifestFileRepositoryPath = $pluginConfiguration['manifest-file']['path'] ?? './drupal_manifest';
+        $this->manifestPackageName = $pluginConfiguration['manifest-file']['name'] ?? 'project/drupal-manifest';
+        $this->preferLowest = $pluginConfiguration['prefer-lowest'] ?? true;
+    }
+
+    public function getDrupalCoreVersionLinkedPackages() {
+        $presentDrupalCorePackages = [];
+        foreach ($this->drupalCoreVersionLinkedPackages as $package) {
+            if ($this->composer->getRepositoryManager()->getLocalRepository()->findPackage($package, '*')) {
+                $presentDrupalCorePackages[] = $package;
+            }
+        }
+        return $presentDrupalCorePackages;
+    }
+
+    public function includeRootDependencies(): bool {
+        return $this->includeRootDependencies;
+    }
+
+    public function ignorePlatformReqs(): bool {
+        return $this->ignorePlatformReqs;
+    }
+
+    public function getManifestFileRepositoryPath(): string {
+        return $this->manifestFileRepositoryPath;
+    }
+
+    public function getManifestPackageName(): string {
+        return $this->manifestPackageName;
+    }
+
+    public function preferLowest(): bool {
+        return $this->preferLowest;
+    }
+}

--- a/src/InputAwareInterface.php
+++ b/src/InputAwareInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace DigitalPolygon\Composer\Drupal\VersionChanger;
+
+use Symfony\Component\Console\Input\InputInterface;
+
+interface InputAwareInterface {
+    public function setInput(InputInterface $input);
+    public function getInput(): InputInterface|null;
+}

--- a/src/InputAwareTrait.php
+++ b/src/InputAwareTrait.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace DigitalPolygon\Composer\Drupal\VersionChanger;
+
+use Symfony\Component\Console\Input\InputInterface;
+
+trait InputAwareTrait {
+
+    protected ?InputInterface $input = null;
+
+    public function setInput(InputInterface $input) {
+        $this->input = $input;
+    }
+
+    public function getInput(): InputInterface|null {
+        return $this->input;
+    }
+}

--- a/src/OutputAwareInterface.php
+++ b/src/OutputAwareInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace DigitalPolygon\Composer\Drupal\VersionChanger;
+
+use Symfony\Component\Console\Output\OutputInterface;
+
+interface OutputAwareInterface {
+    public function setOutput(OutputInterface $input);
+    public function getOutput(): OutputInterface|null;
+}

--- a/src/OutputAwareTrait.php
+++ b/src/OutputAwareTrait.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace DigitalPolygon\Composer\Drupal\VersionChanger;
+
+
+use Symfony\Component\Console\Output\OutputInterface;
+
+trait OutputAwareTrait {
+
+    protected ?OutputInterface $input = null;
+
+    public function setOutput(OutputInterface $input) {
+        $this->input = $input;
+    }
+
+    public function getOutput(): OutputInterface|null {
+        return $this->input;
+    }
+}

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -55,7 +55,8 @@ class Plugin implements PluginInterface, Capable
         ->addArgument('io')
         ->addArgument('composerManipulator');
       $container->addShared('composerManipulator', ComposerManipulator::class)
-        ->addArgument('composer');
+        ->addArgument('composer')
+        ->addArgument('configuration');
       $container->addShared('configuration', Configuration::class)
         ->addArgument('composer');
       static::$container = $container;

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -62,7 +62,8 @@ class Plugin implements PluginInterface, Capable
         ->addArgument('composer');
       $container->addShared('updateRunner', UpdateRunner::class)
           ->addArgument('io')
-          ->addArgument('composer');
+          ->addArgument('composer')
+          ->addArgument('configuration');
 
       static::$container = $container;
     }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -60,6 +60,10 @@ class Plugin implements PluginInterface, Capable
         ->addArgument('configuration');
       $container->addShared('configuration', Configuration::class)
         ->addArgument('composer');
+      $container->addShared('updateRunner', UpdateRunner::class)
+          ->addArgument('io')
+          ->addArgument('composer');
+
       static::$container = $container;
     }
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -53,7 +53,8 @@ class Plugin implements PluginInterface, Capable
         ->addArgument('composer')
         ->addArgument('filesystem')
         ->addArgument('io')
-        ->addArgument('composerManipulator');
+        ->addArgument('composerManipulator')
+        ->addArgument('configuration');
       $container->addShared('composerManipulator', ComposerManipulator::class)
         ->addArgument('composer')
         ->addArgument('configuration');

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -56,6 +56,8 @@ class Plugin implements PluginInterface, Capable
         ->addArgument('composerManipulator');
       $container->addShared('composerManipulator', ComposerManipulator::class)
         ->addArgument('composer');
+      $container->addShared('configuration', Configuration::class)
+        ->addArgument('composer');
       static::$container = $container;
     }
 

--- a/src/UpdateRunner.php
+++ b/src/UpdateRunner.php
@@ -19,22 +19,21 @@ class UpdateRunner implements ApplicationAwareInterface, OutputAwareInterface {
     ) {}
 
     public function updateCore(string $targetDrupalCoreVersion): int {
-        /** @var Configuration $configuration */
         $packages = array_merge([$this->configuration->getManifestPackageName()], array_map(
             fn($package) => $package . ':' . $targetDrupalCoreVersion,
-            $configuration->getDrupalCoreVersionLinkedPackages(),
+            $this->configuration->getDrupalCoreVersionLinkedPackages(),
         ));
         $parameters = [
             'packages' => $packages,
             '--minimal-changes' => true,
         ];
-        if ($configuration->includeRootDependencies()) {
+        if ($this->configuration->includeRootDependencies()) {
             $parameters['-W'] = true;
         }
         else {
             $parameters['-w'] = true;
         }
-        if ($configuration->preferLowest()) {
+        if ($this->configuration->preferLowest()) {
             $parameters['--prefer-lowest'] = true;
         }
         $parameters = array_merge($parameters, $this->commonParameters());

--- a/src/UpdateRunner.php
+++ b/src/UpdateRunner.php
@@ -37,18 +37,13 @@ class UpdateRunner implements ApplicationAwareInterface, OutputAwareInterface {
         if ($configuration->preferLowest()) {
             $parameters['--prefer-lowest'] = true;
         }
-        if ($configuration->ignorePlatformReqs()) {
-            $parameters['--ignore-platform-reqs'] = true;
-        }
+        $parameters = array_merge($parameters, $this->commonParameters());
         return $this->runComposerUpdate($parameters);
     }
 
     public function updateLock(): int {
         $this->getApplication()->resetComposer();
-        $parameters = ['--lock' => true];
-        if ($this->configuration->ignorePlatformReqs()) {
-            $parameters['--ignore-platform-reqs'] = true;
-        }
+        $parameters = array_merge(['--lock' => true], $this->commonParameters());
         return $this->runComposerUpdate($parameters);
     }
 
@@ -60,9 +55,6 @@ class UpdateRunner implements ApplicationAwareInterface, OutputAwareInterface {
         if (!$this->getOutput()) {
             $this->setOutput(new NullOutput());
             $this->io->writeError('<warning>Update command will run but may not output to the console.</warning>');
-        }
-        if ($this->io->isInteractive() && !array_key_exists('--no-interaction', $parameters)) {
-            $parameters['--no-interaction'] = true;
         }
         $update_command = $this->getApplication()->find('update');
         // Run composer update and capture the exit code.
@@ -76,5 +68,22 @@ class UpdateRunner implements ApplicationAwareInterface, OutputAwareInterface {
             $this->io->write('<info>Composer update completed successfully.</info>');
         }
         return 0;
+    }
+
+    protected function commonParameters(): array {
+        $parameters = [];
+        if ($this->io->isInteractive()) {
+            $parameters['--no-interaction'] = true;
+        }
+        if ($this->configuration->noScripts()) {
+            $parameters['--no-scripts'] = true;
+        }
+        if ($this->configuration->noPlugins()) {
+            $parameters['--no-plugins'] = true;
+        }
+        if ($this->configuration->ignorePlatformReqs()) {
+            $parameters['--ignore-platform-reqs'] = true;
+        }
+        return $parameters;
     }
 }

--- a/src/UpdateRunner.php
+++ b/src/UpdateRunner.php
@@ -70,18 +70,18 @@ class UpdateRunner implements ApplicationAwareInterface, OutputAwareInterface {
     }
 
     protected function commonParameters(): array {
-        $parameters = [];
-        if ($this->io->isInteractive()) {
-            $parameters['--no-interaction'] = true;
+        $parameters['--no-interaction'] = $this->io->isInteractive();
+        $parameters['--no-scripts'] = $this->configuration->noScripts();
+        $parameters['--no-plugins'] = $this->configuration->noPlugins();
+        $parameters['--ignore-platform-reqs'] = $this->configuration->ignorePlatformReqs();
+        if ($this->configuration->ignorePlatformReqs()) {
+            $this->io->write('<warning>Upgraded packages may be incompatible with platform requirements (i.e. PHP platform version).</warning>');
         }
         if ($this->configuration->noScripts()) {
-            $parameters['--no-scripts'] = true;
+            $this->io->write('<warning>Scripts will not be executed during the update process.</warning>');
         }
         if ($this->configuration->noPlugins()) {
-            $parameters['--no-plugins'] = true;
-        }
-        if ($this->configuration->ignorePlatformReqs()) {
-            $parameters['--ignore-platform-reqs'] = true;
+            $this->io->write('<warning>Plugins will not be executed during the update process.</warning>');
         }
         return $parameters;
     }

--- a/src/UpdateRunner.php
+++ b/src/UpdateRunner.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace DigitalPolygon\Composer\Drupal\VersionChanger;
+
+use Composer\Composer;
+use Composer\IO\IOInterface;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
+
+class UpdateRunner implements ApplicationAwareInterface, OutputAwareInterface {
+
+    use ApplicationAwareTrait;
+    use OutputAwareTrait;
+
+    public function __construct(
+        protected readonly IOInterface $io,
+        protected readonly Composer $composer,
+        protected readonly Configuration $configuration,
+    ) {}
+
+    public function updateCore(string $targetDrupalCoreVersion): int {
+        /** @var Configuration $configuration */
+        $packages = array_merge([$this->configuration->getManifestPackageName()], array_map(
+            fn($package) => $package . ':' . $targetDrupalCoreVersion,
+            $configuration->getDrupalCoreVersionLinkedPackages(),
+        ));
+        $parameters = [
+            'packages' => $packages,
+            '--minimal-changes' => true,
+        ];
+        if ($configuration->includeRootDependencies()) {
+            $parameters['-W'] = true;
+        }
+        else {
+            $parameters['-w'] = true;
+        }
+        if ($configuration->preferLowest()) {
+            $parameters['--prefer-lowest'] = true;
+        }
+        if ($configuration->ignorePlatformReqs()) {
+            $parameters['--ignore-platform-reqs'] = true;
+        }
+        return $this->runComposerUpdate($parameters);
+    }
+
+    public function updateLock(): int {
+        $this->getApplication()->resetComposer();
+        $parameters = ['--lock' => true];
+        if ($this->configuration->ignorePlatformReqs()) {
+            $parameters['--ignore-platform-reqs'] = true;
+        }
+        return $this->runComposerUpdate($parameters);
+    }
+
+    protected function runComposerUpdate($parameters): int {
+        if (!$this->getApplication()) {
+            $this->io->writeError('Cannot run update command before access to the Composer application is available.');
+            return 1;
+        }
+        if (!$this->getOutput()) {
+            $this->setOutput(new NullOutput());
+            $this->io->writeError('<warning>Update command will run but may not output to the console.</warning>');
+        }
+        if ($this->io->isInteractive() && !array_key_exists('--no-interaction', $parameters)) {
+            $parameters['--no-interaction'] = true;
+        }
+        $update_command = $this->getApplication()->find('update');
+        // Run composer update and capture the exit code.
+        $input = new ArrayInput($parameters);
+        $exit_code = $update_command->run($input, $this->getOutput());
+        // Check for errors.
+        if ($exit_code !== 0) {
+            $this->io->writeError("Failed to run 'composer update', Could not update dependencies.");
+            return $exit_code;
+        } else {
+            $this->io->write('<info>Composer update completed successfully.</info>');
+        }
+        return 0;
+    }
+}

--- a/src/UpdateRunner.php
+++ b/src/UpdateRunner.php
@@ -78,10 +78,10 @@ class UpdateRunner implements ApplicationAwareInterface, OutputAwareInterface {
             $this->io->write('<warning>Upgraded packages may be incompatible with platform requirements (i.e. PHP platform version).</warning>');
         }
         if ($this->configuration->noScripts()) {
-            $this->io->write('<warning>Scripts will not be executed during the update process.</warning>');
+            $this->io->write('<warning>Scripts will not be executed during the Drupal core update process.</warning>');
         }
         if ($this->configuration->noPlugins()) {
-            $this->io->write('<warning>Plugins will not be executed during the update process.</warning>');
+            $this->io->write('<warning>Plugins will not be executed during the Drupal core update process.</warning>');
         }
         return $parameters;
     }


### PR DESCRIPTION
Fixes #7 

Introduce the following configuration options in `extra.drupal-upgrade-plugin`:

- `no-scripts` true/false
- `no-plugins` true/false
- `prefer-lowest` true/false
- `manifest-file.path` relative path to directory containing
- `manifest-file.name` package name in manifest composer.json
- `include-root-dependencies` true/false whether to upgrade packages in root composer.json
- `ignore-platform-reqs` true/false
- `packages-linked-to-core-version` array of drupal core related packages whose versions are linked to drupal core version