### PR TITLE
Add : void to ComposerUpdateDrupalCommand::initialize() for Composer compatibility

### DIFF
--- a/src/ComposerUpdateDrupalCommand.php
+++ b/src/ComposerUpdateDrupalCommand.php
@@ -39,7 +39,7 @@ final class ComposerUpdateDrupalCommand extends BaseCommand
     /**
      * {@inheritdoc}
      */
-    public function initialize(InputInterface $input, OutputInterface $output)
+    public function initialize(InputInterface $input, OutputInterface $output): void
     {
         Plugin::getContainer()
             ->inflector(ApplicationAwareInterface::class)


### PR DESCRIPTION
## Summary

The command overrides `initialize()` without the `: void` return type that Composer's `BaseCommand::initialize(): void` declares. Under a modern Composer this is a fatal "declaration must be compatible" error that aborts **any** composer command in a project that installs this plugin — currently breaking CI in downstream packages (e.g. digitalpolygon/polymer-drupal).

Adds the `: void` return type. `configure(): void` and `execute(): int` were already correct; this is the only affected method.

A `2.0.3-alpha` prerelease will be cut from `main` once this merges so downstream `^2@dev` consumers pick it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)